### PR TITLE
fix: llm generates a response with input containing double quotes

### DIFF
--- a/llm_integration/llm.py
+++ b/llm_integration/llm.py
@@ -17,7 +17,8 @@ local_path = (
 llm = GPT4All(model=local_path, backend="gptj")
 
 TEMPLATE = """
-You are smart AI assistant. You will try to answer the questions or perform the task in best possible way
+You are smart AI assistant. You will answer the question or perform the task in best possible way.
+Do not try to complete the user question or add onto it, just answer it or perform the task.
 Question/Task :{question}"""
 
 prompt = PromptTemplate(template=TEMPLATE, input_variables=["question"])
@@ -36,4 +37,6 @@ def get_llm_answer(text):
     # Clean the text by removing emojis and images
     clean_text = re.sub(r':[^:]+:', '', text)  # Removes Slack emojis
     clean_text = re.sub(r'<[^>]+>', '', clean_text)  # Removes image URLs or any Slack-specific markup
+    # Replace double quotes with another symbol
+    clean_text = re.sub(r'"([^"]*)"', r'<\1>', clean_text)
     return llm_prompt(question=clean_text)

--- a/slack_integration/actions.py
+++ b/slack_integration/actions.py
@@ -16,6 +16,11 @@ def regenerate_response_ephemeral(ack, body):
 
     ai_response = get_ai_response(question)
 
+    if not ai_response:
+        ai_response = """
+        Could not generate a response, please try again later, or rephrase your question.
+        """
+
     try:
         requests.post(
             body["response_url"],
@@ -51,6 +56,11 @@ def regenerate_response_message(ack, body):
         return
 
     ai_response = get_ai_response(question)
+
+    if not ai_response:
+        ai_response = """
+        Could not generate a response, please try again later, or rephrase your question.
+        """
 
     try:
         requests.post(

--- a/slack_integration/direct_messages.py
+++ b/slack_integration/direct_messages.py
@@ -22,6 +22,11 @@ def handle_direct_message(client, event):
     # Get AI response
     ai_response = get_ai_response(question)
 
+    if not ai_response:
+        ai_response = """
+        Could not generate a response, please try again later, or rephrase your question.
+        """
+
     if loading_message is None:
         send_slack_message(
             client,

--- a/slack_integration/slash_commands.py
+++ b/slack_integration/slash_commands.py
@@ -33,6 +33,11 @@ def askai(ack, command, client):
     # get ai response
     ai_response = get_ai_response(question)
 
+    if not ai_response:
+        ai_response = """
+        Could not generate a response, please try again later, or rephrase your question.
+        """
+
     try:
         client.chat_postEphemeral(
             channel=command["channel_id"],


### PR DESCRIPTION
**Issue Resolved:**
Closes #1.

**Description:**
This PR fixes the exception received while handling json in response. The exception was occurring due to the llm not being able to generate a response when the input text contained double quotes like in the following prompt:

> Rephrase this as professional email "Hello Ali,
> I have received a request from our client to resume the work before the expected timeline. I have checked with they are yet to be assigned to a new project.
> Kindly reassign them on erp for the team on a part time hourly basis.
> Moreover, I would suggest that we keep looking for new opportunities for both of them as their current assignment with is not full time."

The function `get_ai_response()` returned `null` which raised the exception when trying to send the response to slack.

**Fix:**

The modifications implemented include:

1. Updated the `get_llm_answer()` function to replace double quotes with angled brackets ("<" at the beginning and ">" at the end) so that the cleaned text sent to the llm generates response.
2. Addition of an extra measure to check if the language model (LLM) generated a response; if not, an error message is sent to the user.